### PR TITLE
fix(cache): invalidate edge cache on new deploy

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -5,6 +5,7 @@ declare global {
 		interface Platform {
 			env: {
 				TOKEN_SECRET?: string;
+				CF_VERSION_METADATA?: { id: string; tag: string; timestamp: string };
 			};
 		}
 	}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -4,6 +4,19 @@ import * as Sentry from '@sentry/sveltekit';
 import { sequence } from '@sveltejs/kit/hooks';
 import { paraglideMiddleware } from '$lib/paraglide/server';
 import { sentryConfig } from '$lib/sentry';
+import { setCacheVersion } from '$lib/server/dku-fetch';
+
+let versionSet = false;
+const versionHandle: Handle = ({ event, resolve }) => {
+	if (!versionSet) {
+		const id = event.platform?.env?.CF_VERSION_METADATA?.id;
+		if (id) {
+			setCacheVersion(id);
+			versionSet = true;
+		}
+	}
+	return resolve(event);
+};
 
 const paraglideHandle: Handle = ({ event, resolve }) =>
 	paraglideMiddleware(event.request, ({ request: localizedRequest, locale }) => {
@@ -16,6 +29,7 @@ const paraglideHandle: Handle = ({ event, resolve }) =>
 export const handle = sequence(
 	initCloudflareSentryHandle(sentryConfig),
 	sentryHandle(),
+	versionHandle,
 	paraglideHandle
 );
 

--- a/src/lib/server/dku-fetch.ts
+++ b/src/lib/server/dku-fetch.ts
@@ -2,6 +2,11 @@ import { traceCacheGet } from './tracing';
 
 export const BASE_URL = 'https://timetable.dku.kz';
 
+let cacheVersion = '';
+export function setCacheVersion(v: string) {
+	cacheVersion = v;
+}
+
 // Worst case staleness is EDGE_TTL + CLIENT_TTL
 export const EDGE_TTL_SECONDS = 3600;
 export const CLIENT_TTL_SECONDS = 1800;
@@ -12,7 +17,7 @@ const inflight = new Map<string, Promise<unknown>>();
 
 export async function cached<T>(key: string, compute: () => Promise<T>): Promise<T> {
 	const cache = typeof caches !== 'undefined' ? caches.default : null;
-	const url = `${BASE_URL}/_cache/${encodeURIComponent(key)}`;
+	const url = `${BASE_URL}/_cache/${cacheVersion}/${encodeURIComponent(key)}`;
 
 	if (cache) {
 		const hit = await traceCacheGet(key, async (setHit) => {


### PR DESCRIPTION
Cloudflare Cache API entries persisted across deploys, causing stale
data until s-maxage expiry. Use the CF_VERSION_METADATA binding to
namespace cache keys by worker version ID so each deployment
automatically starts with a fresh cache.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>