### PR TITLE
perf(calendar): cache ICS output and reduce subscription polling

### DIFF
--- a/src/lib/server/ics.ts
+++ b/src/lib/server/ics.ts
@@ -84,5 +84,8 @@ export function buildIcsCalendar(
 		events: icsEvents
 	};
 
-	return generateIcsCalendar(calendar);
+	return generateIcsCalendar(calendar).replace(
+		'BEGIN:VCALENDAR',
+		'BEGIN:VCALENDAR\r\nX-PUBLISHED-TTL:PT1D'
+	);
 }

--- a/src/routes/api/calendar/+server.ts
+++ b/src/routes/api/calendar/+server.ts
@@ -4,6 +4,7 @@ import {
 	getMeta,
 	pickRollingWeeksForCalendar
 } from '$lib/server/dku';
+import { cached } from '$lib/server/dku-fetch';
 import { buildIcsCalendar } from '$lib/server/ics';
 import { traceSerialize } from '$lib/server/tracing';
 import { verifyToken } from '$lib/server/token';
@@ -29,17 +30,22 @@ export const GET: RequestHandler = async ({ url, platform }) => {
 	const lang = payload.l === 'de' ? 'de' : 'ru';
 	const meta = await getMeta();
 	const weeks = pickRollingWeeksForCalendar(meta.weeks, '', { windowSize: CALENDAR_ROLLING_WEEKS });
+	const weekKeys = weeks.map((w) => w.value).join(',');
+	const cohortKey = [...payload.c].sort().join(',');
+	const cacheKey = `ics:${payload.g}:${lang}:${cohortKey}:${weekKeys}`;
 
-	const schedules = await Promise.all(
-		weeks.map((week) => buildMergedSchedule(payload.g, week.value, payload.c, meta))
-	);
-	const events = schedules.flatMap((s) => s.events);
+	const calendar = await cached(cacheKey, async () => {
+		const schedules = await Promise.all(
+			weeks.map((week) => buildMergedSchedule(payload.g, week.value, payload.c, meta))
+		);
+		const events = schedules.flatMap((s) => s.events);
 
-	const group = meta.groups.find((g) => g.codeRaw === payload.g);
-	const calendarTitle = buildCalendarTitle(group?.codeRu ?? payload.g);
-	const calendar = traceSerialize('buildIcsCalendar', { eventCount: events.length }, () =>
-		buildIcsCalendar(calendarTitle, events, lang)
-	);
+		const group = meta.groups.find((g) => g.codeRaw === payload.g);
+		const calendarTitle = buildCalendarTitle(group?.codeRu ?? payload.g);
+		return traceSerialize('buildIcsCalendar', { eventCount: events.length }, () =>
+			buildIcsCalendar(calendarTitle, events, lang)
+		);
+	});
 
 	return new Response(calendar, {
 		headers: {


### PR DESCRIPTION
Wrap the full schedule-fetch + ICS-build pipeline in cached() so
repeat requests (Apple Calendar polling) return a pre-built string
from CF Cache instead of re-fetching 4 weeks of schedule data and
re-serializing on every hit.

Add X-PUBLISHED-TTL:PT1D to the ICS output to suggest daily refresh
to calendar clients, reducing unnecessary polling.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>