### PR TITLE
perf(sentry): increase trace sample rate from 5% to 25%

### DIFF
--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -2,6 +2,6 @@ import { dev } from '$app/environment';
 
 export const sentryConfig = {
 	dsn: 'https://2b9222adeea60d9dbaef826f52937788@o4510862703722496.ingest.us.sentry.io/4510862792589312',
-	tracesSampleRate: 0.05,
+	tracesSampleRate: 0.25,
 	enabled: !dev && !import.meta.env.VITE_SENTRY_DISABLED
 } as const;


### PR DESCRIPTION
Raise tracesSampleRate from 0.05 to 0.25 to capture more
performance data while staying well within the free-tier
span quota (~45K/month vs 100K+ limit).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>